### PR TITLE
Add tunnel option for Colab server deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,40 @@ Run the following command to kill the distributed server:
 bash simulation/kill_all_server.sh
 ```
 
+### 2.5 Using on Google Colab
+
+1. Clone the repository and install dependencies in a Colab cell:
+
+   ```bash
+   !git clone https://github.com/TangJiakai/GenSim.git
+   %cd GenSim
+   !pip install -r requirements.txt
+   ```
+
+2. (Optional) Launch embedding and LLM services as described above.
+
+3. Start the agent server and expose it to the internet. Set `--tunnel` to
+   `ngrok` or `localtunnel` to obtain a public URL:
+
+   ```bash
+   !python simulation/launch_server.py --scenario chatting --tunnel ngrok
+   ```
+
+   For `ngrok`, ensure that your `NGROK_AUTH_TOKEN` environment variable is
+   configured. Using `localtunnel` requires Node.js and `npx` support.
+
+4. Run the simulator in another cell:
+
+   ```bash
+   !python simulation/examples/chatting/simulator.py
+   ```
+
+5. After finishing, terminate the server:
+
+   ```bash
+   !bash simulation/kill_all_server.sh
+   ```
+
 ## 3. Efficiency and Effectiveness of GenSim
 ### 3.1 Efficiency
 #### 3.1.1 Time Cost :vs: Agent Quality 

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ transformers==4.44.2
 trl==0.11.0
 uvicorn==0.31.0
 wandb==0.18.3
+pyngrok==7.1.6


### PR DESCRIPTION
## Summary
- add utility to expose server via ngrok or localtunnel
- allow `simulation/launch_server.py` to open a public tunnel
- document Colab usage and include pyngrok dependency

## Testing
- `python -m py_compile simulation/helpers/utils.py simulation/launch_server.py`
- `python - <<'PY'
import pyngrok
print(pyngrok.__version__)
PY`


------
https://chatgpt.com/codex/tasks/task_e_68b5ab8d3a90832ebc6a359ba20141f1